### PR TITLE
Add curriculum generator service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
-# Alex-project-one-
+# Curriculum Generator Web Service
+
+## Setup
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Set the `OPENAI_API_KEY` environment variable with your OpenAI API key.
+3. Run the Flask development server:
+   ```bash
+   python app.py
+   ```
+4. Test the `/generate` endpoint with `curl`:
+   ```bash
+   curl -X POST -H "Content-Type: application/json" -d '{"topic": "Python programming"}' http://localhost:5000/generate
+   ```

--- a/app.py
+++ b/app.py
@@ -1,0 +1,42 @@
+import os
+from flask import Flask, request, jsonify
+from schemas import CurriculumRequest, CurriculumResponse
+from openai_client import generate_curriculum
+
+app = Flask(__name__)
+
+@app.route('/generate', methods=['POST'])
+def generate():
+    """Endpoint to generate a curriculum for a given topic."""
+    try:
+        data = request.get_json(force=True)
+    except Exception:
+        return jsonify({'error': 'Invalid JSON payload'}), 400
+
+    # Validate input using Pydantic
+    try:
+        req = CurriculumRequest(**data)
+    except Exception as e:
+        return jsonify({'error': str(e)}), 400
+
+    # Ensure topic is not empty
+    if not req.topic.strip():
+        return jsonify({'error': 'topic must not be empty'}), 400
+
+    # Call the OpenAI client to generate curriculum
+    try:
+        curriculum_dict = generate_curriculum(req.topic)
+    except Exception as e:
+        return jsonify({'error': str(e)}), 502
+
+    # Validate output using Pydantic
+    try:
+        curriculum = CurriculumResponse(**curriculum_dict)
+    except Exception as e:
+        return jsonify({'error': 'Invalid curriculum data returned from OpenAI'}), 502
+
+    return jsonify(curriculum.dict()), 200
+
+if __name__ == '__main__':
+    # Run the Flask development server
+    app.run(host='0.0.0.0', port=int(os.environ.get('PORT', 5000)))

--- a/openai_client.py
+++ b/openai_client.py
@@ -1,0 +1,45 @@
+import os
+import openai
+import json
+from typing import Any, Dict
+
+# Retrieve the API key from environment variable
+openai.api_key = os.getenv('OPENAI_API_KEY')
+
+def generate_curriculum(topic: str) -> Dict[str, Any]:
+    """Call the OpenAI API to generate curriculum data."""
+    if not openai.api_key:
+        raise RuntimeError('OPENAI_API_KEY environment variable not set')
+
+    prompt = (
+        'Generate a learning curriculum as JSON strictly following this schema:\n'
+        '{"topic": "string", "curriculum": [{"module_number": 1, "title": "string",'
+        ' "description": "string", "resources": [{"url": "string", "description": "string"}],'
+        ' "exercise": "string", "quiz": [{"question": "string", "answers": ["string"],'
+        ' "correct_answer_index": 0}]}]}'
+        f'\nTopic: {topic}\nReturn JSON only.'
+    )
+
+    try:
+        response = openai.ChatCompletion.create(
+            model='gpt-3.5-turbo',
+            messages=[{'role': 'user', 'content': prompt}],
+            temperature=0.7,
+        )
+    except Exception as e:
+        raise RuntimeError(f'OpenAI API request failed: {e}')
+
+    try:
+        content = response['choices'][0]['message']['content']
+    except (KeyError, IndexError) as e:
+        raise RuntimeError('Invalid response structure from OpenAI') from e
+
+    try:
+        data = json.loads(content)
+    except Exception as e:
+        raise RuntimeError('Failed to parse JSON from OpenAI response') from e
+
+    # Basic validation of expected keys
+    if 'topic' not in data or 'curriculum' not in data:
+        raise RuntimeError('Missing expected fields in OpenAI response')
+    return data

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+flask
+pydantic
+openai

--- a/schemas.py
+++ b/schemas.py
@@ -1,0 +1,31 @@
+from typing import List
+from pydantic import BaseModel
+
+class Resource(BaseModel):
+    """Represents an external resource link."""
+    url: str
+    description: str
+
+class QuizQuestion(BaseModel):
+    """Represents a question in the quiz."""
+    question: str
+    answers: List[str]
+    correct_answer_index: int
+
+class CurriculumModule(BaseModel):
+    """A single module in the curriculum."""
+    module_number: int
+    title: str
+    description: str
+    resources: List[Resource]
+    exercise: str
+    quiz: List[QuizQuestion]
+
+class CurriculumResponse(BaseModel):
+    """Response model for the generated curriculum."""
+    topic: str
+    curriculum: List[CurriculumModule]
+
+class CurriculumRequest(BaseModel):
+    """Request model containing the desired topic."""
+    topic: str


### PR DESCRIPTION
## Summary
- set up a Flask web service for curriculum generation
- validate requests and responses with Pydantic
- call OpenAI via helper
- document setup and usage

## Testing
- `python -m py_compile app.py openai_client.py schemas.py`

------
https://chatgpt.com/codex/tasks/task_e_684112d3631c8325847444f2c655ecfc