### PR TITLE
Add interactive Flask curriculum generator with tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,15 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Run tests
+        run: PYTHONPATH=. pytest --maxfail=1 --disable-warnings -q

--- a/app.py
+++ b/app.py
@@ -1,0 +1,47 @@
+from flask import Flask, request, jsonify
+from schemas import CurriculumRequest, CurriculumResponse
+import openai_client
+import time
+import logging
+
+app = Flask(__name__, static_folder='static', static_url_path='')
+logging.basicConfig(level=logging.INFO)
+
+@app.route('/', methods=['GET'])
+def homepage():
+    return app.send_static_file('index.html')
+
+@app.route('/generate', methods=['POST'])
+def generate():
+    try:
+        data = request.get_json(force=True)
+    except Exception:
+        return jsonify({'error': 'Invalid JSON payload'}), 400
+
+    try:
+        req = CurriculumRequest(**data)
+    except Exception as e:
+        return jsonify({'error': str(e)}), 400
+
+    if not req.topic.strip():
+        return jsonify({'error': 'topic must not be empty'}), 400
+
+    start_time = time.time()
+    try:
+        curriculum_dict = openai_client.generate_curriculum(req.topic)
+    except Exception as e:
+        logging.error(f"Error generating curriculum: {e}")
+        return jsonify({'error': str(e)}), 502
+    latency = time.time() - start_time
+    logging.info(f"Generated curriculum for '{req.topic}' in {latency:.2f}s")
+
+    try:
+        curriculum = CurriculumResponse(**curriculum_dict)
+    except Exception as e:
+        logging.error("Invalid curriculum data from OpenAI")
+        return jsonify({'error': 'Invalid curriculum data from OpenAI'}), 502
+
+    return jsonify(curriculum.dict()), 200
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/openai_client.py
+++ b/openai_client.py
@@ -1,0 +1,49 @@
+import os
+import openai
+import json
+import logging
+from typing import Any, Dict
+from functools import lru_cache
+
+logging.basicConfig(level=logging.INFO)
+openai.api_key = os.getenv('OPENAI_API_KEY')
+
+@lru_cache(maxsize=128)
+def _call_openai_for_curriculum(topic: str) -> Dict[str, Any]:
+    prompt = (
+        'Generate a learning curriculum as JSON strictly following this schema:\n'
+        '{"topic":"string","curriculum":[{"module_number":1,"title":"string",'
+        '"description":"string","resources":[{"url":"string","description":"string"}],'
+        '"exercise":"string","quiz":[{"question":"string","answers":["string"],"correct_answer_index":0}]}]}\n'
+        f'\nTopic: {topic}\nReturn JSON only.'
+    )
+    try:
+        response = openai.ChatCompletion.create(
+            model=os.getenv('OPENAI_MODEL', 'gpt-3.5-turbo'),
+            messages=[{'role': 'user', 'content': prompt}],
+            temperature=0.2,
+        )
+    except Exception as e:
+        logging.error(f"OpenAI API request failed: {e}")
+        raise RuntimeError(f"OpenAI failure: {e}")
+
+    try:
+        content = response['choices'][0]['message']['content']
+    except (KeyError, IndexError) as e:
+        logging.error("Invalid response structure from OpenAI")
+        raise RuntimeError("Invalid response structure from OpenAI") from e
+
+    try:
+        data = json.loads(content)
+    except Exception as e:
+        logging.error("Failed to parse JSON from OpenAI response")
+        raise RuntimeError("JSON parse error") from e
+
+    if 'topic' not in data or 'curriculum' not in data:
+        logging.error("Missing fields in OpenAI response")
+        raise RuntimeError("Missing expected fields in OpenAI response")
+    return data
+
+def generate_curriculum(topic: str) -> Dict[str, Any]:
+    logging.info(f"Generating curriculum for topic: {topic}")
+    return _call_openai_for_curriculum(topic)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+flask
+openai
+pydantic
+pytest

--- a/schemas.py
+++ b/schemas.py
@@ -1,0 +1,26 @@
+from pydantic import BaseModel, validator
+from typing import List
+
+class CurriculumRequest(BaseModel):
+    topic: str
+
+class Resource(BaseModel):
+    url: str
+    description: str
+
+class QuizQuestion(BaseModel):
+    question: str
+    answers: List[str]
+    correct_answer_index: int
+
+class CurriculumModule(BaseModel):
+    module_number: int
+    title: str
+    description: str
+    resources: List[Resource]
+    exercise: str
+    quiz: List[QuizQuestion]
+
+class CurriculumResponse(BaseModel):
+    topic: str
+    curriculum: List[CurriculumModule]

--- a/static/index.html
+++ b/static/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Curriculum Generator</title>
+</head>
+<body>
+  <h1>Curriculum Generator</h1>
+  <input type="text" id="topic-input" placeholder="Enter a topic" />
+  <button id="generate-btn">Generate</button>
+  <div id="result"></div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/static/script.js
+++ b/static/script.js
@@ -1,0 +1,56 @@
+document.getElementById('generate-btn').addEventListener('click', async () => {
+  const topic = document.getElementById('topic-input').value.trim();
+  if (!topic) {
+    alert('Please enter a topic');
+    return;
+  }
+  document.getElementById('result').innerHTML = '<p>Generating…</p>';
+  try {
+    const response = await fetch('/generate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ topic })
+    });
+    if (!response.ok) {
+      const err = await response.json();
+      document.getElementById('result').innerHTML = `<p style="color:red;">Error: ${err.error}</p>`;
+      return;
+    }
+    const data = await response.json();
+    renderCurriculum(data.curriculum);
+  } catch (e) {
+    document.getElementById('result').innerHTML = `<p style="color:red;">Network error</p>`;
+  }
+});
+
+function renderCurriculum(modules) {
+  const container = document.getElementById('result');
+  container.innerHTML = '';
+  modules.forEach((mod) => {
+    const modDiv = document.createElement('div');
+    modDiv.innerHTML = `
+      <h2>Module ${mod.module_number}: ${mod.title}</h2>
+      <p>${mod.description}</p>
+      <h3>Resources:</h3>
+      <ul>
+        ${mod.resources.map(r => `<li><a href="${r.url}" target="_blank">${r.description}</a></li>`).join('')}
+      </ul>
+      <p><strong>Exercise:</strong> ${mod.exercise}</p>
+      <h3>Quiz:</h3>
+      <ol>
+        ${mod.quiz.map(q => `
+          <li>
+            <p><strong>Q:</strong> ${q.question}</p>
+            <ul>
+              ${q.answers.map((a, i) => `
+                <li ${i === q.correct_answer_index ? 'style="font-weight:bold;"' : ''}>
+                  ${a}
+                </li>`).join('')}
+            </ul>
+          </li>`).join('')}
+      </ol>
+      <hr />
+    `;
+    container.appendChild(modDiv);
+  });
+}

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -1,0 +1,14 @@
+import pytest
+from app import app
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    with app.test_client() as client:
+        yield client
+
+def test_homepage_serves_index(client):
+    resp = client.get('/')
+    assert resp.status_code == 200
+    assert b'<input' in resp.data
+    assert b'id="generate-btn"' in resp.data

--- a/tests/test_generate_endpoint.py
+++ b/tests/test_generate_endpoint.py
@@ -1,0 +1,45 @@
+import pytest
+from app import app
+from openai_client import generate_curriculum as real_gen
+
+@pytest.fixture(autouse=True)
+def patch_generate(monkeypatch):
+    def fake_generate(topic):
+        return {
+            "topic": topic,
+            "curriculum": [
+                {
+                    "module_number": 1,
+                    "title": "Test Module",
+                    "description": "Desc",
+                    "resources": [{"url": "http://example.com", "description": "Example"}],
+                    "exercise": "Do this",
+                    "quiz": [{"question": "Q?", "answers": ["A1","A2"], "correct_answer_index": 0}]
+                }
+            ]
+        }
+    monkeypatch.setattr('openai_client.generate_curriculum', fake_generate)
+    yield
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    with app.test_client() as client:
+        yield client
+
+def test_generate_success(client):
+    resp = client.post('/generate', json={'topic': 'Demo'})
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data['topic'] == 'Demo'
+    assert isinstance(data['curriculum'], list)
+
+def test_generate_missing_topic(client):
+    resp = client.post('/generate', json={'topic': ''})
+    assert resp.status_code == 400
+    data = resp.get_json()
+    assert 'error' in data
+
+def test_generate_invalid_json(client):
+    resp = client.post('/generate', data='not-json')
+    assert resp.status_code == 400


### PR DESCRIPTION
## Summary
- implement Flask app with static HTML/JS frontend
- add OpenAI client with caching and logging
- include data schemas
- create tests for frontend and API
- configure CI workflow

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68411578012483258077302b2e9ed7a6